### PR TITLE
add handling of seed in reset

### DIFF
--- a/dmc2gymnasium/DMCGym.py
+++ b/dmc2gymnasium/DMCGym.py
@@ -2,11 +2,12 @@
 
 import logging
 import os
-from gymnasium.spaces import Box
-from gymnasium.core import Env
+
 import numpy as np
 from dm_control import suite
 from dm_env import specs
+from gymnasium.core import Env
+from gymnasium.spaces import Box
 
 
 def _spec_to_box(spec, dtype=np.float32):
@@ -111,10 +112,10 @@ class DMCGym(Env):
         return observation, reward, termination, truncation, info
 
     def reset(self, seed=None, options=None):
-        if seed:
-            logging.warn(
-                "Currently DMC has no way of seeding episodes. It only allows to seed experiments on environment initialization"
-            )
+        if seed is not None:
+            if not isinstance(seed, np.random.RandomState):
+                seed = np.random.RandomState(seed)
+            self._env.task._random = seed
 
         if options:
             logging.warn("Currently doing nothing with options={:}".format(options))


### PR DESCRIPTION
Adds a work around to use seeding when calling reset

```
from dmc2gymnasium import DMCGym

env = DMCGym("walker", "walk")

obs, info = env.reset(seed=13)
print(obs)

obs, info = env.reset()
print(obs)

obs, info = env.reset(seed=13)
print(obs)
```
output:
```
[-0.1731818   0.98488986 -0.02561726  0.9996718  -0.4667902   0.88436806
  0.24346751  0.9699091   0.998381    0.05687983  0.08292393  0.99655586
  0.25157064  0.96783894  1.3         0.          0.          0.
  0.          0.          0.          0.          0.          0.        ]
[-0.15970106  0.98716545  0.7408521   0.6716682   0.10638192  0.99432534
 -0.5841069   0.81167674  0.11536003  0.99332374 -0.71204156 -0.70213735
 -0.97643465 -0.21581337  1.3         0.          0.          0.
  0.          0.          0.          0.          0.          0.        ]
[-0.1731818   0.98488986 -0.02561726  0.9996718  -0.4667902   0.88436806
  0.24346751  0.9699091   0.998381    0.05687983  0.08292393  0.99655586
  0.25157064  0.96783894  1.3         0.          0.          0.
  0.          0.          0.          0.          0.          0.        ]
```
